### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY entrypoint.sh /hamlet/
 WORKDIR /hamlet
 RUN pipenv install --system --deploy
 
-ENV DJANGO_SETTINGS_MODULE "hamlet.settings.local"
+ENV DJANGO_SETTINGS_MODULE "hamlet.settings.docker"
 
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.6
+
+RUN python3.6 -m pip install pipenv
+
+COPY hamlet/ /hamlet/hamlet/
+COPY Pipfile* /hamlet/
+COPY manage.py /hamlet/
+COPY entrypoint.sh /hamlet/
+WORKDIR /hamlet
+RUN pipenv install --system --deploy
+
+ENV DJANGO_SETTINGS_MODULE "hamlet.settings.local"
+
+EXPOSE 8000
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.4"
+
+services:
+  db:
+    image: postgres
+  web:
+    build: .
+    image: hamlet
+    volumes:
+      - hamlet:/data
+    environment:
+      DJANGO_DB: postgres
+      DJANGO_DB_USER: postgres
+      DJANGO_DB_HOST: db
+      DJANGO_MODEL_PATH:
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+volumes:
+  hamlet:
+    name: hamlet

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -82,21 +82,21 @@ hamlet.model is a copy of all_theses_no_split_w4_s52.model. This is a model trai
 These models don't represent the entire MIT thesis collection (that's what lets them be smaller), so don't be surprised if documents of interest are not present.
 
 `hamlet.settings.local` defaults to using the test model, since it is checked
-into version control. If you have a different model you want to use, set `DJANGO_MODEL_PATH=relative/path/to/model` in `.env`.
+into version control. If you have a different model you want to use, set `DJANGO_MODEL_PATH=/full/path/to/model` in `.env`.
 
 ## Docker
 You can start up a running instance locally using docker compose:
 
 ```
-docker-compose up
+$ docker-compose up
 ```
 
 By default, this will use the test model included in the codebase. If you'd like to use a different model, you will need to add it to a hamlet docker volume. This volume is mounted as `/data` in the container. You'll also need to set the `DJANGO_MODEL_PATH` env var to point to the model within that docker volume. Assuming your model files are in the top directory of the project:
 
 ```
-docker run --name hamlet-data --mount type=volume,src=hamlet,target=/data busybox true
-for f in hamlet.model*; do docker cp $f hamlet-data:/data; done
-docker rm hamlet-data
-export DJANGO_MODEL_PATH=/data/hamlet.model
-docker-compose up
+$ docker run --name hamlet-data --mount type=volume,src=hamlet,target=/data busybox true
+$ for f in hamlet.model*; do docker cp $f hamlet-data:/data; done
+$ docker rm hamlet-data
+$ export DJANGO_MODEL_PATH=/data/hamlet.model
+$ docker-compose up
 ```

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -55,6 +55,7 @@ You may set the following environment variables to configure your database:
 * `DJANGO_DB` (default `hamlet`)
 * `DJANGO_DB_USER` (default `hamlet`)
 * `DJANGO_DB_PASSWORD` (no default)
+* `DJANGO_DB_HOST` (default `localhost`)
 
 If you are running with the Postgres default, be sure to stand up Postgres; create the named database and user; and grant privileges on your database to your user.
 
@@ -82,3 +83,20 @@ These models don't represent the entire MIT thesis collection (that's what lets 
 
 `hamlet.settings.local` defaults to using the test model, since it is checked
 into version control. If you have a different model you want to use, set `DJANGO_MODEL_PATH=relative/path/to/model` in `.env`.
+
+## Docker
+You can start up a running instance locally using docker compose:
+
+```
+docker-compose up
+```
+
+By default, this will use the test model included in the codebase. If you'd like to use a different model, you will need to add it to a hamlet docker volume. This volume is mounted as `/data` in the container. You'll also need to set the `DJANGO_MODEL_PATH` env var to point to the model within that docker volume. Assuming your model files are in the top directory of the project:
+
+```
+docker run --name hamlet-data --mount type=volume,src=hamlet,target=/data busybox true
+for f in hamlet.model*; do docker cp $f hamlet-data:/data; done
+docker rm hamlet-data
+export DJANGO_MODEL_PATH=/data/hamlet.model
+docker-compose up
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+python3.6 manage.py migrate
+python3.6 manage.py collectstatic --noinput
+python3.6 manage.py compress
+
+gunicorn hamlet.wsgi -b 0.0.0.0:8000 -w 2

--- a/hamlet/settings/base.py
+++ b/hamlet/settings/base.py
@@ -86,7 +86,7 @@ DATABASES = {
         'NAME': os.environ.get('DJANGO_DB', 'hamlet'),
         'USER': os.environ.get('DJANGO_DB_USER', 'hamlet'),
         'PASSWORD': os.environ.get('DJANGO_DB_PASSWORD'),
-        'HOST': 'localhost',
+        'HOST': os.environ.get('DJANGO_DB_HOST', 'localhost'),
         'PORT': '',
     }
 }

--- a/hamlet/settings/docker.py
+++ b/hamlet/settings/docker.py
@@ -1,0 +1,48 @@
+# This file is designed for use with docker.
+from gensim.models.doc2vec import Doc2Vec
+import os
+
+from .base import *  # noqa
+
+ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost']
+
+SECRET_KEY = 'f=fqwc&$zt_6rf8y45j1l7w!^e*%a_c)4sf+v*_uf%hwf5_*16'
+
+MIDDLEWARE.insert(1, 'whitenoise.middleware.WhiteNoiseMiddleware')
+
+STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+
+# MODEL_FILE is the full path of the neural net model to be used.
+# *Make sure the test file is not .gitignored*; it is needed for CI.
+# However, production-quality models are too big for GitHub, so they should be
+# .gitignored.
+# MODEL_FILE defaults to the test model used for CI; because it is checked into
+# the repo it should be present and is therefore a sensible default for local
+# development. If you want to have a production-like environment, and to use
+# a model that represents the entire database, get it separately; set the
+# env var DJANGO_MODEL_PATH to the full path to the neural net model.
+MODEL_FILE = os.environ.get('DJANGO_MODEL_PATH',
+                            os.path.join(PROJECT_DIR, 'testmodels', 'testmodel.model'))
+NEURAL_NET = Doc2Vec.load(MODEL_FILE)
+
+COMPRESS_ENABLED = True
+COMPRESS_OFFLINE = True
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'WARN'),
+        },
+    },
+}

--- a/hamlet/settings/local.py
+++ b/hamlet/settings/local.py
@@ -4,7 +4,7 @@ import os
 
 from .heroku import *  # noqa
 
-ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost']
+ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1:8000']
 
 SECRET_KEY = 'f=fqwc&$zt_6rf8y45j1l7w!^e*%a_c)4sf+v*_uf%hwf5_*16'
 
@@ -15,10 +15,14 @@ SECRET_KEY = 'f=fqwc&$zt_6rf8y45j1l7w!^e*%a_c)4sf+v*_uf%hwf5_*16'
 # MODEL_FILE defaults to the test model used for CI; because it is checked into
 # the repo it should be present and is therefore a sensible default for local
 # development. If you want to have a production-like environment, and to use
-# a model that represents the entire database, get it separately; set the
-# env var DJANGO_MODEL_PATH to the full path to the neural net model.
-MODEL_FILE = os.environ.get('DJANGO_MODEL_PATH',
-                            os.path.join(PROJECT_DIR, 'testmodels', 'testmodel.model'))
+# a model that represents the entire database, get it separately; put it in
+# hamlet/model/hamlet.model; and add DJANGO_USE_LIVE_MODEL=True to your .env.
+modelpath = os.environ.get('DJANGO_MODEL_path', '')
+if modelpath:
+    MODEL_FILE = os.path.join(PROJECT_DIR, modelpath)
+else:
+    MODEL_FILE = os.path.join(PROJECT_DIR, 'testmodels', 'testmodel.model')
+
 NEURAL_NET = Doc2Vec.load(MODEL_FILE)
 
 # The string "PASSED" will pass any captcha.

--- a/hamlet/settings/local.py
+++ b/hamlet/settings/local.py
@@ -4,7 +4,7 @@ import os
 
 from .heroku import *  # noqa
 
-ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1:8000']
+ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost']
 
 SECRET_KEY = 'f=fqwc&$zt_6rf8y45j1l7w!^e*%a_c)4sf+v*_uf%hwf5_*16'
 
@@ -15,14 +15,10 @@ SECRET_KEY = 'f=fqwc&$zt_6rf8y45j1l7w!^e*%a_c)4sf+v*_uf%hwf5_*16'
 # MODEL_FILE defaults to the test model used for CI; because it is checked into
 # the repo it should be present and is therefore a sensible default for local
 # development. If you want to have a production-like environment, and to use
-# a model that represents the entire database, get it separately; put it in
-# hamlet/model/hamlet.model; and add DJANGO_USE_LIVE_MODEL=True to your .env.
-modelpath = os.environ.get('DJANGO_MODEL_path', '')
-if modelpath:
-    MODEL_FILE = os.path.join(PROJECT_DIR, modelpath)
-else:
-    MODEL_FILE = os.path.join(PROJECT_DIR, 'testmodels', 'testmodel.model')
-
+# a model that represents the entire database, get it separately; set the
+# env var DJANGO_MODEL_PATH to the full path to the neural net model.
+MODEL_FILE = os.environ.get('DJANGO_MODEL_PATH',
+                            os.path.join(PROJECT_DIR, 'testmodels', 'testmodel.model'))
 NEURAL_NET = Doc2Vec.load(MODEL_FILE)
 
 # The string "PASSED" will pass any captcha.


### PR DESCRIPTION
This adds a Dockerfile and docker-compose.yml file. There is only one potentially breaking change; in order to work in a container I needed to change the DJANGO_MODEL_PATH envvar to a full path instead of a relative path. I think I was the only one using this anyways.